### PR TITLE
chore: update the flag url creation

### DIFF
--- a/dotnet/DynatraceOneAgentHook.cs
+++ b/dotnet/DynatraceOneAgentHook.cs
@@ -48,7 +48,10 @@ namespace Hooks
                 if (variableMetadata.FeatureId != null)
                 {
                     activity.SetTag("feature_flag.set.id", variableMetadata.FeatureId);
-                    activity.SetTag("feature_flag.url", $"https://app.devcycle.com/r/p/{context.Metadata.Project.Id}/f/{variableMetadata.FeatureId}");
+                    if (variableMetadata.ProjectId != null)
+                    {
+                        activity.SetTag("feature_flag.url", $"https://app.devcycle.com/r/p/{variableMetadata.ProjectId}/f/{variableMetadata.FeatureId}");
+                    }
                 }
                 if (variableDetails.Eval != null)
                 {

--- a/java/DynatraceOneAgentHook.java
+++ b/java/DynatraceOneAgentHook.java
@@ -80,6 +80,9 @@ public class DynatraceOneAgentHook implements EvalHook<Object> {
 
                     if (variableMetadata != null && variableMetadata.featureId != null) {
                         span.setAttribute("feature_flag.set.id", variableMetadata.featureId);
+                        if (variableMetadata.projectId != null) {
+                            span.setAttribute("feature_flag.url", "https://app.devcycle.com/r/p/" + variableMetadata.projectId +  "/f/" + variableMetadata.featureId);
+                        }
                     }
 
                     log.debug("Feature flag span completed: {} = {}", var.getKey(), var.getValue());


### PR DESCRIPTION
- add the flag url to the span attributes


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
