### PR TITLE
feat: add otel span hooks for java and dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # DevCycle Integration Hooks
 
-This repository contains the integration hooks for the DevCycle SDKs.
+This repository contains the integration hooks for DevCycle SDKs made as a drop in hook for your current applications.
 
-There are language specific folders for each SDK and there are usage examples for each language.
+These hooks are designed to send feature flag evaluation traces to your observability platform.
 
-Supported SDKs:
+There are language specific folders for each SDK and there are usage examples for each language. You can copy the hook files into your project and add them to your DevCycle client. You can also use the hooks as a reference to implement your own hook.
+
+## Example Hooks for SDKs:
 
 - [java](java)
 - [.NET](dotnet)
+
+Contact us at support@devcycle.com if you have any questions or feedback.

--- a/dotnet/OpenTelemetrySpanHook.cs
+++ b/dotnet/OpenTelemetrySpanHook.cs
@@ -1,0 +1,86 @@
+using System.Diagnostics;
+using System.Collections.Concurrent;
+using DevCycle.SDK.Server.Common.Model;
+
+namespace Hooks
+{
+    public class OpenTelemetrySpanHook : EvalHook
+    {
+        private readonly ActivitySource _activitySource;
+        private readonly ConcurrentDictionary<string, Activity> _activities = new();
+
+        public ActivityHook(ActivitySource activitySource)
+        {
+            _activitySource = activitySource;
+        }
+
+        public override async Task<HookContext<T>> BeforeAsync<T>(HookContext<T> context, CancellationToken cancellationToken = default)
+        {
+            var activity = _activitySource.StartActivity($"feature_flag_evaluation.{context.Key}");
+
+            if (activity != null)
+            {
+                var activityKey = $"{context.Key}_{context.User.UserId}";
+
+                activity.SetTag("feature_flag.key", context.Key);
+                activity.SetTag("feature_flag.provider.name", "devcycle");
+                activity.SetTag("feature_flag.context.id", context.User.UserId);
+                activity.SetTag("feature_flag.value_type", context.DefaultValue.GetType().Name);
+
+                if (context.Metadata != null)
+                {
+                    activity.SetTag("feature_flag.project", context.Metadata.Project?.Id);
+                    activity.SetTag("feature_flag.environment", context.Metadata.Environment?.Id);
+                }
+
+                _activities.TryAdd(activityKey, activity);
+            }
+
+            return await Task.FromResult(context);
+        }
+
+        public override Task AfterAsync<T>(HookContext<T> context, Variable<T> variableDetails, VariableMetadata variableMetadata, CancellationToken cancellationToken = default)
+        {
+            var activityKey = $"{context.Key}_{context.User.UserId}";
+            if (_activities.TryGetValue(activityKey, out var activity))
+            {
+                activity.SetTag("feature_flag.result.value", variableDetails.Value.ToString());
+                if (variableMetadata.FeatureId != null)
+                {
+                    activity.SetTag("feature_flag.set.id", variableMetadata.FeatureId);
+                    if (context.Metadata.Project?.Id != null)
+                    {
+                        activity.SetTag("feature_flag.url", $"https://app.devcycle.com/r/p/{context.Metadata.Project.Id}/f/{variableMetadata.FeatureId}");
+                    }
+                }
+                if (variableDetails.Eval != null)
+                {
+                    activity.SetTag("feature_flag.result.reason", variableDetails.Eval.Reason);
+                    activity.SetTag("feature_flag.result.reason.details", variableDetails.Eval.Details);
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        public override Task ErrorAsync<T>(HookContext<T> context, System.Exception error, CancellationToken cancellationToken = default)
+        {
+            var activityKey = $"{context.Key}_{context.User.UserId}";
+            if (_activities.TryGetValue(activityKey, out var activity))
+            {
+                activity.SetTag("feature_flag.error_message", error.Message);
+                activity.SetTag("error.type", error.GetType().Name);
+            }
+            return Task.CompletedTask;
+        }
+
+        public override Task FinallyAsync<T>(HookContext<T> context, Variable<T> variableDetails, VariableMetadata variableMetadata, CancellationToken cancellationToken = default)
+        {
+            var activityKey = $"{context.Key}_{context.User.UserId}";
+            if (_activities.TryRemove(activityKey, out var activity))
+            {
+                activity.Stop();
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -1,8 +1,6 @@
-
 # DevCycle Feature Flag Evaluation Hooks for .NET SDK
 
 This repository provides evaluation hooks for the DevCycle .NET SDK that enable observability and tracing of feature flag evaluations.
-
 
 ## Usage
 
@@ -31,6 +29,23 @@ Copy the DynatraceOneAgentHook.cs file into your project and include it in your 
 This hook leverages OpenTelemetry to instrument feature flag evaluations, creating traces that Dynatrace OneAgent automatically collects when properly configured.
 
 When OpenTelemetry is configured in your application, the hook will send feature flag evaluation traces to your designated observability platform.
+
+# OpenTelemetrySpanHook
+
+Copy the OpenTelemetrySpanHook.cs file into your project and include it in your build.
+
+## Integrating the hook with your DevCycle client
+
+```c#
+// Initialize DevCycle client with standard configuration
+DevCycleLocalClient client = new DevCycleLocalClientBuilder()
+    .SetSDKKey("<DEVCYCLE_SERVER_SDK_KEY>")
+    .SetLogger(LoggerFactory.Create(builder => builder.AddConsole()))
+    .Build();
+
+// Initialize evaluation hook with an ActivitySource for tracing
+client.AddEvalHook(new OpenTelemetrySpanHook(new ActivitySource("DevCycle.FlagEvaluations")));
+```
 
 # OtelLogHook
 

--- a/java/DynatraceOneAgentHook.java
+++ b/java/DynatraceOneAgentHook.java
@@ -43,8 +43,6 @@ public class DynatraceOneAgentHook implements EvalHook<Object> {
                         span.setAttribute("feature_flag.environment", ctx.getMetadata().environment.id);
                     }
                 }
-
-                log.debug("Feature flag evaluation span started for key: {}", ctx.getKey());
             }
 
             spans.put(ctx, span);
@@ -57,10 +55,6 @@ public class DynatraceOneAgentHook implements EvalHook<Object> {
 
     public void after(HookContext<Object> ctx, Optional<Variable<Object>> variable, VariableMetadata variableMetadata) {
         // DevCycle calls onFinally instead of after, so we don't handle span completion here
-        log.debug("after called for key: {} (span completion handled in onFinally)", ctx.getKey());
-        log.warn("variableMetadata: {}", variableMetadata != null ? variableMetadata.toString() : "null");
-        log.warn("variable: {}", variable != null ? variable.get().toString() : "null");
-        log.warn("ctx: {}", ctx != null ? ctx.toString() : "null");
     }
 
     public void onFinally(HookContext<Object> ctx, Optional<Variable<Object>> variable, VariableMetadata variableMetadata) {
@@ -68,8 +62,6 @@ public class DynatraceOneAgentHook implements EvalHook<Object> {
             Span span = spans.remove(ctx);
 
             if (span != null) {
-                log.debug("Completing feature flag evaluation span for key: {}", ctx.getKey());
-                log.warn("variableMetadata: {}", variableMetadata != null ? variableMetadata.toString() : "null");
 
                 if (variable.isPresent()) {
                     Variable<Object> var = variable.get();
@@ -86,18 +78,15 @@ public class DynatraceOneAgentHook implements EvalHook<Object> {
                         }
                     }
 
-                    log.debug("Feature flag span completed: {} = {}", var.getKey(), var.getValue());
                 } else {
                     span.setAttribute("feature_flag.result.value", "null");
                     span.setAttribute("feature_flag.result.reason", "evaluation_failed");
-                    log.debug("Feature flag evaluation failed for key: {}", ctx.getKey());
                 }
 
                 span.end();
-                log.debug("Feature flag span ended for key: {}", ctx.getKey());
 
             } else {
-                log.warn("No span found for feature flag key: {}", ctx.getKey());
+                log.debug("No span found for feature flag key: {}", ctx.getKey());
             }
         } catch (Exception e) {
             log.error("Error completing feature flag span for key {}: {}", ctx.getKey(), e.getMessage());

--- a/java/OpenTelemetrySpanHook.java
+++ b/java/OpenTelemetrySpanHook.java
@@ -1,0 +1,111 @@
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.devcycle.sdk.server.common.model.EvalHook;
+import com.devcycle.sdk.server.common.model.HookContext;
+import com.devcycle.sdk.server.common.model.Variable;
+import com.devcycle.sdk.server.local.model.VariableMetadata;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+
+@RequiredArgsConstructor
+@Slf4j
+public class OpenTelemetrySpanHook implements EvalHook<Object> {
+
+    private Tracer tracer;
+    private final Map<HookContext<Object>, Span> spans = new ConcurrentHashMap<>();
+
+    public Optional<HookContext<Object>> before(HookContext<Object> ctx) {
+        try {
+            tracer = GlobalOpenTelemetry.get().getTracer("devcycle-tracer");
+            Span span = tracer.spanBuilder("feature_flag_evaluation." + ctx.getKey())
+                    .setSpanKind(SpanKind.INTERNAL)
+                    .startSpan();
+
+            if (span != null) {
+                span.setAttribute("feature_flag.provider.name", "devcycle");
+                span.setAttribute("feature_flag.key", ctx.getKey());
+                span.setAttribute("feature_flag.value_type", ctx.getDefaultValue().getClass().getSimpleName());
+                span.setAttribute("feature_flag.context.id", ctx.getUser().getUserId());
+
+                if (ctx.getMetadata() != null) {
+                    if (ctx.getMetadata().project != null && ctx.getMetadata().project.id != null) {
+                        span.setAttribute("feature_flag.project", ctx.getMetadata().project.id);
+                    }
+                    if (ctx.getMetadata().environment != null && ctx.getMetadata().environment.id != null) {
+                        span.setAttribute("feature_flag.environment", ctx.getMetadata().environment.id);
+                    }
+                }
+
+                log.debug("Feature flag evaluation span started for key: {}", ctx.getKey());
+            }
+
+            spans.put(ctx, span);
+            return Optional.empty();
+        } catch (Exception e) {
+            log.error("Error starting feature flag span for key {}: {}", ctx.getKey(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    public void after(HookContext<Object> ctx, Optional<Variable<Object>> variable, VariableMetadata variableMetadata) {
+        // DevCycle calls onFinally instead of after, so we don't handle span completion here
+        log.debug("after called for key: {} (span completion handled in onFinally)", ctx.getKey());
+        log.warn("variableMetadata: {}", variableMetadata != null ? variableMetadata.toString() : "null");
+        log.warn("variable: {}", variable != null ? variable.get().toString() : "null");
+        log.warn("ctx: {}", ctx != null ? ctx.toString() : "null");
+    }
+
+    public void onFinally(HookContext<Object> ctx, Optional<Variable<Object>> variable, VariableMetadata variableMetadata) {
+        try {
+            Span span = spans.remove(ctx);
+
+            if (span != null) {
+                log.debug("Completing feature flag evaluation span for key: {}", ctx.getKey());
+                log.warn("variableMetadata: {}", variableMetadata != null ? variableMetadata.toString() : "null");
+
+                if (variable.isPresent()) {
+                    Variable<Object> var = variable.get();
+                    span.setAttribute("feature_flag.result.value", String.valueOf(var.getValue()));
+
+                    if (var.getEval() != null && var.getEval().getReason() != null) {
+                        span.setAttribute("feature_flag.result.reason", var.getEval().getReason());
+                    }
+
+                    if (variableMetadata != null && variableMetadata.featureId != null) {
+                        span.setAttribute("feature_flag.set.id", variableMetadata.featureId);
+                        if (ctx.getMetadata() != null && ctx.getMetadata().project != null && ctx.getMetadata().project.id != null) {
+                            span.setAttribute("feature_flag.url", "https://app.devcycle.com/r/p/" + ctx.getMetadata().project.id +  "/f/" + variableMetadata.featureId);
+                        }
+                    }
+
+                    log.debug("Feature flag span completed: {} = {}", var.getKey(), var.getValue());
+                } else {
+                    span.setAttribute("feature_flag.result.value", "null");
+                    span.setAttribute("feature_flag.result.reason", "evaluation_failed");
+                    log.debug("Feature flag evaluation failed for key: {}", ctx.getKey());
+                }
+
+                span.end();
+                log.debug("Feature flag span ended for key: {}", ctx.getKey());
+
+            } else {
+                log.warn("No span found for feature flag key: {}", ctx.getKey());
+            }
+        } catch (Exception e) {
+            log.error("Error completing feature flag span for key {}: {}", ctx.getKey(), e.getMessage());
+        }
+    }
+
+    public void error(HookContext<Object> ctx, Exception e) {
+        log.warn("error: {}", ctx.getKey());
+        log.warn("e: {}", e.getMessage());
+    }
+}

--- a/java/OpenTelemetrySpanHook.java
+++ b/java/OpenTelemetrySpanHook.java
@@ -43,8 +43,6 @@ public class OpenTelemetrySpanHook implements EvalHook<Object> {
                         span.setAttribute("feature_flag.environment", ctx.getMetadata().environment.id);
                     }
                 }
-
-                log.debug("Feature flag evaluation span started for key: {}", ctx.getKey());
             }
 
             spans.put(ctx, span);
@@ -57,10 +55,6 @@ public class OpenTelemetrySpanHook implements EvalHook<Object> {
 
     public void after(HookContext<Object> ctx, Optional<Variable<Object>> variable, VariableMetadata variableMetadata) {
         // DevCycle calls onFinally instead of after, so we don't handle span completion here
-        log.debug("after called for key: {} (span completion handled in onFinally)", ctx.getKey());
-        log.warn("variableMetadata: {}", variableMetadata != null ? variableMetadata.toString() : "null");
-        log.warn("variable: {}", variable != null ? variable.get().toString() : "null");
-        log.warn("ctx: {}", ctx != null ? ctx.toString() : "null");
     }
 
     public void onFinally(HookContext<Object> ctx, Optional<Variable<Object>> variable, VariableMetadata variableMetadata) {
@@ -68,8 +62,6 @@ public class OpenTelemetrySpanHook implements EvalHook<Object> {
             Span span = spans.remove(ctx);
 
             if (span != null) {
-                log.debug("Completing feature flag evaluation span for key: {}", ctx.getKey());
-                log.warn("variableMetadata: {}", variableMetadata != null ? variableMetadata.toString() : "null");
 
                 if (variable.isPresent()) {
                     Variable<Object> var = variable.get();
@@ -86,18 +78,15 @@ public class OpenTelemetrySpanHook implements EvalHook<Object> {
                         }
                     }
 
-                    log.debug("Feature flag span completed: {} = {}", var.getKey(), var.getValue());
                 } else {
                     span.setAttribute("feature_flag.result.value", "null");
                     span.setAttribute("feature_flag.result.reason", "evaluation_failed");
-                    log.debug("Feature flag evaluation failed for key: {}", ctx.getKey());
                 }
 
                 span.end();
-                log.debug("Feature flag span ended for key: {}", ctx.getKey());
 
             } else {
-                log.warn("No span found for feature flag key: {}", ctx.getKey());
+                log.debug("No span found for feature flag key: {}", ctx.getKey());
             }
         } catch (Exception e) {
             log.error("Error completing feature flag span for key {}: {}", ctx.getKey(), e.getMessage());

--- a/java/README.md
+++ b/java/README.md
@@ -25,3 +25,19 @@ Then, you can use the hooks in your code, copy the DynatraceOneAgentHook.java fi
 The hook is using OpenTelemetry to trace the feature flag evaluation which are automatically picked up by Dynatrace OneAgent if its already configured.
 
 If you have OpenTelemetry configured in your project, you can use the hook to trace the feature flag evaluation and they will go to your configured observability provider.
+
+# OpenTelemetrySpanHook
+
+Copy the OpenTelemetrySpanHook.java file into your project and include it in your build.
+
+## Integrating the hook with your DevCycle client
+
+```java
+    // Create DevCycle client with default options
+    devCycleClient = new DevCycleLocalClient(devCycleServerSdkKey);
+
+    // Add OpenTelemetrySpanHook for all variable types
+    OpenTelemetrySpanHook hook = new OpenTelemetrySpanHook();
+    devCycleClient.addHook(hook);
+
+```


### PR DESCRIPTION
- add span hooks, which are copy of the existing dynatrace hook to be used with otel


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
